### PR TITLE
Fix wrong parameter type of Jenkins.build()

### DIFF
--- a/jenkins.py
+++ b/jenkins.py
@@ -655,8 +655,8 @@ class Jenkins(object):
         return View(name, self.server)
 
     def build(self, name, number):
-        name = name.name if isinstance(name, Job) else name
-        return Build(name, number)
+        job = name if isinstance(name, Job) else self.job(name)
+        return Build(job, number)
 
     def node(self, name):
         return Node(name, self.server)


### PR DESCRIPTION
The original implementation (v0.5.3) of `Jenkins.build()` has an obvious bug.
When invoked (in IPython), there would be error information like this:

```python
/home/yanqd0/jenkins/jenkins-webapi/jenkins.py in build(self, name, number)
    657     def build(self, name, number):
    658         name = name.name if isinstance(name, Job) else name
--> 659         return Build(name, number)
    660 
    661     def node(self, name):

/home/yanqd0/jenkins/jenkins-webapi/jenkins.py in __init__(self, job, number)
    457         self.job = job
    458         self.number = number
--> 459         self.server = self.job.server
    460 
    461     def __hash__(self):

AttributeError: 'str' object has no attribute 'server'
```