### PR TITLE
Fixed regression: jenkins-webapi crashes with "not an XML document"

### DIFF
--- a/jenkins.py
+++ b/jenkins.py
@@ -57,7 +57,7 @@ class _JenkinsBase(object):
     def config(self):
         url = self.url('config.xml')
         res = self.server.get(url)
-        if res.status_code != 200 or res.headers.get('content-type', '').startswith('application/xml'):
+        if res.status_code != 200 or not res.headers.get('content-type', '').startswith('application/xml'):
             msg = 'fetching configuration for item "%s" did not return an xml document'
             raise JenkinsError(msg % self.name)
         return res.text


### PR DESCRIPTION
Hi Georgi, 
it looks like a regression was introduced in jenkins-webapi 3 days ago 
when changing 
`contentType!='application/xml'`
to
`contentType.startsWith('application/xml')`
the latest jenkins-autojobs now always crashes with "not an xml document" error:
```
File "/usr/local/lib/python3.5/dist-packages/jenkins.py", line 65, in config
    raise JenkinsError(msg % self.name)
jenkins.JenkinsError: fetching configuration for item "new-job-template" did not return an xml document
```
This change should take care of it. 

p.s. sorry, can't add a unit test for it, I'm a java/groovy dev and not familiar with pytest. I literally took a 30-minutes crash course in python just now to troubleshoot and fix the issue :) 
